### PR TITLE
Feat/k8s

### DIFF
--- a/microservices/basic-microservices-arch/blog/client/Dockerfile
+++ b/microservices/basic-microservices-arch/blog/client/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:alpine
 
+# Workaround for react-scripts messing with react in docker
+ENV CI=true
+
 WORKDIR /app
 COPY package.json ./
 RUN npm install

--- a/microservices/basic-microservices-arch/blog/client/src/CommentCreate.js
+++ b/microservices/basic-microservices-arch/blog/client/src/CommentCreate.js
@@ -7,7 +7,7 @@ export default function CommentCreate({ postId }) {
   const onSubmit = async (event) => {
     event.preventDefault();
 
-    await axios.post(`http://localhost:4001/posts/${postId}/comments`, { content: comment });
+    await axios.post(`http://posts.com/posts/${postId}/comments`, { content: comment });
     setComment('');
   };
 

--- a/microservices/basic-microservices-arch/blog/client/src/PostCreate.js
+++ b/microservices/basic-microservices-arch/blog/client/src/PostCreate.js
@@ -7,7 +7,7 @@ export default function PostCreate() {
   const onSubmit = async (event) => {
     event.preventDefault();
 
-    await axios.post('http://localhost:4000/posts', { title });
+    await axios.post('http://posts.com/posts/create', { title });
     setTitle('');
   };
 
@@ -16,7 +16,11 @@ export default function PostCreate() {
       <form onSubmit={onSubmit}>
         <div className="form-group">
           <label>Title</label>
-          <input className="form-control" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <input
+            className="form-control"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
         </div>
         <button className="btn btn-primary">Submit</button>
       </form>

--- a/microservices/basic-microservices-arch/blog/client/src/PostList.js
+++ b/microservices/basic-microservices-arch/blog/client/src/PostList.js
@@ -9,7 +9,7 @@ export default function PostList() {
 
   useEffect(() => {
     const fetchPosts = async () => {
-      const { data } = await axios.get('http://localhost:4002/posts');
+      const { data } = await axios.get('http://posts.com/posts');
       setPosts(data);
     };
 

--- a/microservices/basic-microservices-arch/blog/comments/index.js
+++ b/microservices/basic-microservices-arch/blog/comments/index.js
@@ -26,7 +26,7 @@ app.post('/posts/:id/comments', async (req, res) => {
     ? [...commentsByPostId[postId], newComment]
     : [newComment];
 
-  await axios.post('http://localhost:4005/events', {
+  await axios.post('http://event-bus-srv:4005/events', {
     type: 'CommentCreated',
     data: { id: commentId, content, postId, status: 'pending' },
   });
@@ -44,7 +44,7 @@ app.post('/events', async (req, res) => {
     const commentToUpdate = comments.find((c) => c.id === id);
     commentToUpdate.status = status;
 
-    await axios.post('http://localhost:4005/events', {
+    await axios.post('http://event-bus-srv:4005/events', {
       type: 'CommentUpdated',
       data: {
         id,

--- a/microservices/basic-microservices-arch/blog/event-bus/index.js
+++ b/microservices/basic-microservices-arch/blog/event-bus/index.js
@@ -14,10 +14,10 @@ app.post('/events', (req, res) => {
   const event = req.body;
   events.push(event);
 
-  axios.post('http://localhost:4000/events', event); // Posts
-  axios.post('http://localhost:4001/events', event); // Comments
-  axios.post('http://localhost:4002/events', event); // Query
-  axios.post('http://localhost:4003/events', event); // Comment moderation
+  axios.post('http://posts-clusterip-srv:4000/events', event); // Posts
+  axios.post('http://comments-srv:4001/events', event); // Comments
+  axios.post('http://query-srv:4002/events', event); // Query
+  axios.post('http://moderation-srv:4003/events', event); // Comment moderation
 
   res.send({ status: 'OK' });
 });

--- a/microservices/basic-microservices-arch/blog/infra/k8s/client-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/client-depl.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      containers:
+        - name: client
+          image: sternshawn/client
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client-srv
+spec:
+  type: ClusterIP
+  selector:
+    app: client
+  ports:
+    - name: client
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/microservices/basic-microservices-arch/blog/infra/k8s/comments-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/comments-depl.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: comments-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: comments
+  template:
+    metadata:
+      labels:
+        app: comments
+    spec:
+      containers:
+        - name: comments
+          image: sternshawn/comments
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comments-srv
+spec:
+  type: ClusterIP
+  selector:
+    app: comments
+  ports:
+    - name: comments
+      protocol: TCP
+      port: 4001
+      targetPort: 4001

--- a/microservices/basic-microservices-arch/blog/infra/k8s/event-bus-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/event-bus-depl.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: event-bus-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: event-bus
+  template:
+    metadata:
+      labels:
+        app: event-bus
+    spec:
+      containers:
+        - name: event-bus
+          image: sternshawn/event-bus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: event-bus-srv
+spec:
+  type: ClusterIP # Optional since type defaults to ClusterIP Service
+  selector:
+    app: event-bus
+  ports:
+    - name: event-bus
+      protocol: TCP
+      port: 4005
+      targetPort: 4005

--- a/microservices/basic-microservices-arch/blog/infra/k8s/ingress-srv.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/ingress-srv.yaml
@@ -4,12 +4,25 @@ metadata:
   name: ingress-srv
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
   rules:
     - host: posts.com
       http:
         paths:
-          - path: /posts
+          - path: /posts/create
             backend:
               serviceName: posts-clusterip-srv
               servicePort: 4000
+          - path: /posts
+            backend:
+              serviceName: query-srv
+              servicePort: 4002
+          - path: /posts/?(.*)/comments
+            backend:
+              serviceName: comments-srv
+              servicePort: 4001
+          - path: /?(.*)
+            backend:
+              serviceName: client-srv
+              servicePort: 3000

--- a/microservices/basic-microservices-arch/blog/infra/k8s/ingress-srv.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/ingress-srv.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-srv
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: posts.com
+      http:
+        paths:
+          - path: /posts
+            backend:
+              serviceName: posts-clusterip-srv
+              servicePort: 4000

--- a/microservices/basic-microservices-arch/blog/infra/k8s/moderation-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/moderation-depl.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moderation-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moderation
+  template:
+    metadata:
+      labels:
+        app: moderation
+    spec:
+      containers:
+        - name: moderation
+          image: sternshawn/moderation
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moderation-srv
+spec:
+  type: ClusterIP
+  selector:
+    app: moderation
+  ports:
+    - name: moderation
+      protocol: TCP
+      port: 4003
+      targetPort: 4003

--- a/microservices/basic-microservices-arch/blog/infra/k8s/posts-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/posts-depl.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: posts-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: posts
+  template:
+    metadata:
+      labels:
+        app: posts # This allows posts-srv to select posts pods via selector
+    spec:
+      containers:
+        - name: posts
+          image: sternshawn/posts
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: posts-clusterip-srv # using a diff name since we already have a posts NodePort service running as posts-srv
+spec:
+  selector:
+    app: posts
+  ports:
+    - name: posts
+      protocol: TCP
+      port: 4000
+      targetPort: 4000

--- a/microservices/basic-microservices-arch/blog/infra/k8s/posts-srv.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/posts-srv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: posts-srv
+spec:
+  type: NodePort
+  selector:
+    app: posts
+  ports:
+    - name: posts
+      protocol: TCP
+      port: 4000 # Port of this NodePort Service that internal requests should be directed to and will be directed to the targetPort
+      targetPort: 4000 # The port of our express server that is listening for traffic

--- a/microservices/basic-microservices-arch/blog/infra/k8s/query-depl.yaml
+++ b/microservices/basic-microservices-arch/blog/infra/k8s/query-depl.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: query
+  template:
+    metadata:
+      labels:
+        app: query
+    spec:
+      containers:
+        - name: query
+          image: sternshawn/query
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: query-srv
+spec:
+  type: ClusterIP
+  selector:
+    app: query
+  ports:
+    - name: query
+      protocol: TCP
+      port: 4002
+      targetPort: 4002

--- a/microservices/basic-microservices-arch/blog/moderation/index.js
+++ b/microservices/basic-microservices-arch/blog/moderation/index.js
@@ -14,7 +14,7 @@ app.post('/events', async (req, res) => {
     const { id, content, postId } = data;
     const status = content.includes('orange') ? 'rejected' : 'approved';
 
-    await axios.post('http://localhost:4005/events', {
+    await axios.post('http://event-bus-srv:4005/events', {
       type: 'CommentModerated',
       data: {
         id,

--- a/microservices/basic-microservices-arch/blog/posts/index.js
+++ b/microservices/basic-microservices-arch/blog/posts/index.js
@@ -21,7 +21,7 @@ app.post('/posts', async (req, res) => {
 
   posts[id] = { id, title };
 
-  await axios.post('http://localhost:4005/events', { type: 'PostCreated', data: posts[id] });
+  await axios.post(`http://event-bus-srv:4005/events`, { type: 'PostCreated', data: posts[id] });
 
   res.status(201).send(posts[id]);
 });
@@ -32,5 +32,6 @@ app.post('/events', async (req, res) => {
 });
 
 app.listen(PORT, () => {
+  console.log('v3, testing k8s deployments with rollouts/restart');
   console.log(`Listening on port ${PORT}`);
 });

--- a/microservices/basic-microservices-arch/blog/posts/index.js
+++ b/microservices/basic-microservices-arch/blog/posts/index.js
@@ -11,11 +11,7 @@ const app = express();
 app.use(bodyParser.json());
 app.use(cors());
 
-app.get('/posts', (req, res) => {
-  res.send(posts);
-});
-
-app.post('/posts', async (req, res) => {
+app.post('/posts/create', async (req, res) => {
   const id = randomBytes(4).toString('hex');
   const { title } = req.body;
 

--- a/microservices/basic-microservices-arch/blog/query/index.js
+++ b/microservices/basic-microservices-arch/blog/query/index.js
@@ -50,7 +50,7 @@ app.listen(PORT, async () => {
   console.log(`Listening on port ${PORT}`);
 
   // Reach out to event bus for a history of all events while this service was down, and synchronize
-  const { data: events } = await axios.get('http://localhost:4005/events');
+  const { data: events } = await axios.get('http://event-bus-srv:4005/events');
 
   events.forEach(({ type, data }) => {
     console.log('Processing event: ', type);

--- a/microservices/basic-microservices-arch/blog/skaffold.yaml
+++ b/microservices/basic-microservices-arch/blog/skaffold.yaml
@@ -1,0 +1,58 @@
+apiVersion: skaffold/v2alpha3
+kind: Config
+deploy:
+  kubectl:
+    manifests:
+      - ./infra/k8s/*
+build:
+  local:
+    push: false
+  artifacts:
+    - image: sternshawn/client
+      context: client
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: 'src/**/*.js'
+            dest: .
+    - image: sternshawn/comments
+      context: comments
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '*.js'
+            dest: .
+    - image: sternshawn/event-bus
+      context: event-bus
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '*.js'
+            dest: .
+    - image: sternshawn/moderation
+      context: moderation
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '*.js'
+            dest: .
+    - image: sternshawn/posts
+      context: posts
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '*.js'
+            dest: .
+    - image: sternshawn/query
+      context: query
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '*.js'
+            dest: .


### PR DESCRIPTION
- Configure each service as a k8s pod
- Create a deployment for each service along with a ClusterIP for inter-pod communication
- Expose the cluster to external comms via a NodePort
- Use Ingress to manage routing from outside world to specific pods by tags
- Simplify running this locally using Skaffold

Note: edit hosts file to point posts.com to localhost for testing